### PR TITLE
Simplify and improve types

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,12 @@
   },
   "dependencies": {
     "postal-mime": "^2.3.2"
+  },
+  "prettier": {
+    "useTabs": false,
+    "singleQuote": true,
+    "semi": false,
+    "printWidth": 100,
+    "trailingComma": "none"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,32 +1,20 @@
-// MIT https://github.com/postalsys/postal-mime/blob/master/LICENSE.txt
-import PostalMime from 'postal-mime';
+import PostalMime from 'postal-mime'
 
 export default {
-  async email(
-    message: ForwardableEmailMessage,
-    env: Env,
-    ctx: ExecutionContext
-  ) {
-    if (message.from !== 'jurgen@ciaosoft.com') {
-      console.log(`Reject email from ${message.from}`);
-      message.setReject(`Not allowed`);
-      return;
-    }
-    console.log(`Received email from ${message.from}`);
+  async email(message, env, ctx) {
+    console.log(`Received email from ${message.from}`)
 
-    // parse for attachments - see readme below for additional options
+    // parse for attachments - see readme for additional options
     // https://github.com/postalsys/postal-mime/tree/master?tab=readme-ov-file#postalmimeparse
-    const email = await PostalMime.parse(message.raw);
+    const email = await PostalMime.parse(message.raw)
     email.attachments.forEach((a) => {
-      if (a.mimeType.startsWith('application/json')) {
-        const jsonString = new TextDecoder().decode(a.content);
-        const jsonValue = JSON.parse(jsonString);
-        console.log(
-          `JSON attachment value:\n${JSON.stringify(jsonValue, null, 2)}`
-        );
+      if (a.mimeType === 'application/json') {
+        const jsonString = new TextDecoder().decode(a.content)
+        const jsonValue = JSON.parse(jsonString)
+        console.log(`JSON attachment value:\n${JSON.stringify(jsonValue, null, 2)}`)
       }
-    });
+    })
 
-    await message.forward('jurgen@haydnlabs.com');
-  },
-};
+    ctx.waitUntil(message.forward('jurgen@haydnlabs.com'))
+  }
+} satisfies ExportedHandler<Env>


### PR DESCRIPTION
simplify the example

- [x] remove email handler parameter types, rely on ExportedHandler instead
- [x] remove sender validation
- [x] run forwarding in ctx.waituntil (verifed that errors are still reported)
- [x] prettier in package.json